### PR TITLE
Replaced encoding func/vars with transliterating

### DIFF
--- a/core/names.js
+++ b/core/names.js
@@ -174,10 +174,15 @@ Blockly.Names.prototype.safeName_ = function(name) {
   if (!name) {
     name = Blockly.Msg['UNNAMED_KEY'] || 'unnamed';
   } else {
-    // Unfortunately names in non-latin characters will look like
-    // _E9_9F_B3_E4_B9_90 which is pretty meaningless.
-    // https://github.com/google/blockly/issues/1654
-    name = encodeURI(name.replace(/ /g, '_')).replace(/[^\w]/g, '_');
+    // Transliterate non-latin charactes.
+    // Replace spaces with underscores
+    // Replace everything that's not a word with underscores
+    if (transliterate) {
+      name = transliterate(name.replace(/ /g, '_')).replace(/[^\w]/g, '_');
+    } else {
+      name = name.replace(/ /g, '_').replace(/[^\w]/g, '_');
+    }
+
     // Most languages don't allow names with leading numbers.
     if ('0123456789'.indexOf(name[0]) != -1) {
       name = 'my_' + name;


### PR DESCRIPTION
When creating functions or variables, writing a name in non-latin characters produces weird code.

For example, a function called асд should transliterate to asd (or remain in cyrillic), åæø should transliterate to aaeo.

Right now, it gets converted to numbers, i.e. BA20%30%AC%U2%11 which makes no sense.

Transliterating is the best approach, in order to avoid any weird Python bugs from running non-latin code.