### PR TITLE
Dropdown waits if the chosen option is not found

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -484,14 +484,32 @@ Blockly.FieldDropdown.prototype.doClassValidation_ = function(opt_newValue) {
     if ((option.length === 1 && option[0] === opt_newValue) || 
         (option[1] == opt_newValue)) {
       isValueValid = true;
+      this.skipTimeout = false;
       break;
     }
   }
   if (!isValueValid) {
     if (this.sourceBlock_) {
+      // Check for two special cases, but only if the skipTimeout flag hasn't been raised yet
+      if (!this.skipTimeout &&
+          (this.sourceBlock_.type === 'fable_imread' ||
+          this.sourceBlock_.type === 'fable_play_custom_sound')) {
+        // Raise the skipTimeout flag
+        this.skipTimeout = true;
+
+        // Set a timeout for 500 ms that will repeat the check.
+        // Used for "dynamic" dropdowns, which are based on FableAPI's response time
+        var thisObj = this;
+        setTimeout(function () {
+          thisObj.setValue(opt_newValue);
+        }, 500);
+
+        return opt_newValue;
+      }
+
       console.warn('Cannot set the dropdown\'s value to an unavailable option.' +
-        ' Block type: ' + this.sourceBlock_.type + ', Field name: ' + this.name +
-        ', Value: ' + opt_newValue);
+          ' Block type: ' + this.sourceBlock_.type + ', Field name: ' + this.name +
+          ', Value: ' + opt_newValue);
     }
     return null;
   }


### PR DESCRIPTION
The `fable_imread` and `fable_play_custom_sound` blocks have a **dynamic** dropdown.

The dropdown's options depend on FableAPI responding. However, when initializing the app, FableAPI responds slower than Blockly initializes its blocks.

This makes any choice in a **dynamic** dropdown be replaced by a default value, e.g. "from feed" or "no sounds found".

In those two cases, I added a 500 ms timeout, along with just ignoring the check, and setting whatever value was selected initially.

If the user runs his/hers code and the selected option is no longer possible, the respective methods of `FableAPI` should throw a warning anyways. (Custom sounds already was throwing a warning, image manipulation didn't, but there's a PR for that as well).