### PR TITLE
Add shadow block when changing module selector

### DIFF
--- a/core/block.js
+++ b/core/block.js
@@ -1993,9 +1993,27 @@ Blockly.Block.prototype.appendDynamicIDInput = function (requestedModuleTypes, m
     var inputExists = this.getInput('#');
     if (inputID) {
       if (!inputExists) {
+        // Add a connector for external blocks
         this.appendValueInput('#').setCheck('String');
+
+        // Create a shadow block with a module selector in it
+        var shadowChild = this.workspace.newBlock('fable_get_module_id');
+        shadowChild.setShadow(true);
+        shadowChild.initSvg();
+        shadowChild.render();
+
+        // Attach the shadow block to the this block (the parent)
+        var parentConnection = this.getInput('#').connection;
+        parentConnection.connect(shadowChild.outputConnection);
       }
     } else if (inputExists) {
+      // Remove any attached shadow blocks
+      var connectedBlock = this.getInput('#').connection.targetBlock();
+      if (connectedBlock && connectedBlock.isShadow()) {
+        connectedBlock.dispose(true, true);
+      }
+
+      // Remove the connector for external blocks
       this.removeInput('#');
     }
   };
@@ -2159,6 +2177,7 @@ Blockly.Block.prototype.appendDrowdownWithMutation = function (fixedOptions,
           // Creates and connects a block to the Value Input.
           if (!skipChild && inputOptions.addBlock) {
             var addedBlock = this.workspace.newBlock(inputOptions.addBlock);
+            addedBlock.setShadow(true);
             addedBlock.initSvg();
             // Customizes fields of the block.
             if (inputOptions.blockFields) {


### PR DESCRIPTION
We have a bunch of blocks in which you select a module ID.

Most of them have the option to select "#" as the module.

This changes the block by adding an external connection.

However, about a year ago, we decided to abolish this, and have shadow blocks automatically attached if possible.

The module ID was one of the long-lasting things that were not putting in a shadow block.

I added it just now:

![shadow2](https://user-images.githubusercontent.com/4217267/76861523-a1d73a80-6854-11ea-8e0b-b26c4c397bcd.png)

![shadow3](https://user-images.githubusercontent.com/4217267/76861524-a26fd100-6854-11ea-98cb-7e2e2121c138.png)

Of course, you can still drag other blocks inside:

![shadow4](https://user-images.githubusercontent.com/4217267/76861526-a3086780-6854-11ea-97d4-b5725dcbf61a.png)

Additionally, I found out one of the camera blocks was dynamically adding a number block inside it. It was not a shadow block, so it could be detached. I fixed this.

![shadow5](https://user-images.githubusercontent.com/4217267/76861747-f975a600-6854-11ea-8304-61cf68d8b379.png)

