### PR TITLE
Vertical block alignment fix for CSS refactor

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -353,6 +353,7 @@ Blockly.Css.CONTENT = [
   '.blocklyEditableText>rect {',
     'fill: #fff;',
     'fill-opacity: .6;',
+    'y: 0;',
   '}',
 
   '.blocklyNonEditableText>text,',
@@ -363,6 +364,14 @@ Blockly.Css.CONTENT = [
   '.blocklyEditableText:hover>rect {',
     'stroke: #fff;',
     'stroke-width: 2;',
+  '}',
+
+  '.blocklyNonEditableText>rect,',
+  '.blocklyEditableText>rect,',
+  '.blocklyNonEditableText>path,',
+  '.blocklyEditableText>path {',
+    'fill-opacity: 0.7;',
+    'y: 0;',
   '}',
 
   '.blocklyBubbleText {',


### PR DESCRIPTION
It turns out that cssminifier.com, the website we use to minify our CSS removes some properties are are deemed "illegal".

Unfortunately, labels inside blocks in the Blockly library make use of these illegal properties, more specifically, `y`.

The culprit was this:
```css
.blocklyNonEditableText>rect,
.blocklyEditableText>rect,
.blocklyNonEditableText>path,
.blocklyEditableText>path {
  fill-opacity: 0.7;
  y: 0;
}
```

`fill-opacity` was left after minification, but `y` was getting removed without any warnings.

So, to fix the issue, I added the CSS above to Blockly's core CSS, which is a giant multi-line string, and most important of all, doesn't get compiled.