### PR TITLE
Workspace search highlight

### DIFF
--- a/core/block_render_svg.js
+++ b/core/block_render_svg.js
@@ -318,23 +318,25 @@ Blockly.BlockSvg.INNER_BOTTOM_LEFT_CORNER_HIGHLIGHT_LTR =
 /**
  * Returns a bounding box describing the dimensions of this block
  * and any blocks stacked below it.
+ * @param {boolean} shouldSkipNextBlock - A boolean for whether to skip recursively
+ * retrieving the following connected blocks. Used in `WorkspaceSvg.centerOnBlock` as that was not centering properly.
  * @return {!{height: number, width: number}} Object with height and width
  *    properties in workspace units.
  */
-Blockly.BlockSvg.prototype.getHeightWidth = function() {
+Blockly.BlockSvg.prototype.getHeightWidth = function (shouldSkipNextBlock) {
   var height = this.height;
   var width = this.width;
   // Recursively add size of subsequent blocks.
   var nextBlock = this.getNextBlock();
-  if (nextBlock) {
+  if (nextBlock && !shouldSkipNextBlock) {
     var nextHeightWidth = nextBlock.getHeightWidth();
-    height += nextHeightWidth.height - 4;  // Height of tab.
+    height += nextHeightWidth.height - 4; // Height of tab.
     width = Math.max(width, nextHeightWidth.width);
   } else if (!this.nextConnection && !this.outputConnection) {
     // Add a bit of margin under blocks with no bottom tab.
     height += 2;
   }
-  return {height: height, width: width};
+  return { height: height, width: width };
 };
 
 /**

--- a/core/block_svg.js
+++ b/core/block_svg.js
@@ -1763,21 +1763,23 @@ Blockly.BlockSvg.prototype.setMarkerSvg = function(markerSvg) {
 /**
  * Returns a bounding box describing the dimensions of this block
  * and any blocks stacked below it.
+ * @param {boolean} shouldSkipNextBlock - A boolean for whether to skip recursively
+ * retrieving the following connected blocks. Used in `WorkspaceSvg.centerOnBlock` as that was not centering properly.
  * @return {!{height: number, width: number}} Object with height and width
  *    properties in workspace units.
  * @package
  */
-Blockly.BlockSvg.prototype.getHeightWidth = function() {
+Blockly.BlockSvg.prototype.getHeightWidth = function (shouldSkipNextBlock) {
   var height = this.height;
   var width = this.width;
   // Recursively add size of subsequent blocks.
   var nextBlock = this.getNextBlock();
-  if (nextBlock) {
+  if (nextBlock && !shouldSkipNextBlock) {
     var nextHeightWidth = nextBlock.getHeightWidth();
-    height += nextHeightWidth.height - 4;  // Height of tab.
+    height += nextHeightWidth.height - 4; // Height of tab.
     width = Math.max(width, nextHeightWidth.width);
   }
-  return {height: height, width: width};
+  return { height: height, width: width };
 };
 
 /**

--- a/core/search.js
+++ b/core/search.js
@@ -151,6 +151,8 @@ Blockly.Search.prototype.clearAll = function () {
   delete this.blockTrie_;
 
   this.blockTrie_ = new Blockly.Trie();
+
+  this.blocksAdded_ = {};
 };
 
 /**

--- a/core/search_workspace.js
+++ b/core/search_workspace.js
@@ -145,12 +145,12 @@ Blockly.WorkspaceSearch.prototype.highlightResult = function (index) {
   this.unhighlightAll();
 
   // Highlight every block except for this one (its a white-ish overlay so blocks look "disabled")
-  const blockKeys = Object.keys(this.blocksAdded_);
-  for (var i = 0; i < blockKeys.length; i++) {
-    if (blockKeys[i] !== resultToShow.id) {
-      this.workspace_.highlightBlock(blockKeys[i], true);
-    }
-  }
+  // const blockKeys = Object.keys(this.blocksAdded_);
+  // for (var i = 0; i < blockKeys.length; i++) {
+  //   if (blockKeys[i] !== resultToShow.id) {
+  //     this.workspace_.highlightBlock(blockKeys[i], true);
+  //   }
+  // }
 
   // Select the result (adds a yellow outline)
   resultToShow.select();

--- a/core/search_workspace.js
+++ b/core/search_workspace.js
@@ -45,6 +45,7 @@ Blockly.WorkspaceSearch.prototype.onBlockAdded = function (type, val) {
     console.warn('Cannot find newly created block with ID ' + val);
     return;
   }
+
   // Get the block's dynamic inputs
   // FieldDropdown / FieldTextInput / FieldBoolean / ButtonInput / AsciiInput / FieldAngle / FieldJointAngle
   // @todo Add any other types that we end up creating
@@ -140,6 +141,18 @@ Blockly.WorkspaceSearch.prototype.highlightResult = function (index) {
 
   // Center the workspace on it and hightlight it
   this.workspace_.centerOnBlock(resultToShow.id);
+
+  this.unhighlightAll();
+
+  // Highlight every block except for this one (its a white-ish overlay so blocks look "disabled")
+  const blockKeys = Object.keys(this.blocksAdded_);
+  for (var i = 0; i < blockKeys.length; i++) {
+    if (blockKeys[i] !== resultToShow.id) {
+      this.workspace_.highlightBlock(blockKeys[i], true);
+    }
+  }
+
+  // Select the result (adds a yellow outline)
   resultToShow.select();
 };
 
@@ -154,7 +167,17 @@ Blockly.WorkspaceSearch.prototype.onCloseSearch = function () {
   Blockly.WorkspaceSearch.superClass_.onCloseSearch.call(this);
 
   // Reset workspace highlighting
+  this.unhighlightAll();
+};
+
+/**
+ * Resets all of the highlighting associated with the search
+ */
+Blockly.WorkspaceSearch.prototype.unhighlightAll = function () {
+  // Reset workspace highlighting
   this.workspace_.highlightBlock('');
+
+  // Unselect any selected blocks
   if (Blockly.selected) {
     Blockly.selected.unselect();
   }

--- a/core/toolbox.js
+++ b/core/toolbox.js
@@ -225,7 +225,7 @@ Blockly.Toolbox.prototype.renderTree = function(languageTree) {
 
   // //If there will be any search logic, clear the current trie (useful when changing Toolboxes - Simple/Advanced)
   // if (this.shouldPopulateSearch_) {
-  //   this.search_.clearAll();
+  this.search_.clearAll();
   // }
 
   if (this.tree_) {

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -1998,7 +1998,7 @@ Blockly.WorkspaceSvg.prototype.centerOnBlock = function(id) {
   // XY is in workspace coordinates.
   var xy = block.getRelativeToSurfaceXY();
   // Height/width is in workspace units.
-  var heightWidth = block.getHeightWidth();
+  var heightWidth = block.getHeightWidth(true);
 
   // Find the enter of the block in workspace units.
   var blockCenterY = xy.y + heightWidth.height / 2;


### PR DESCRIPTION
Fixes a small calculation bug with the workspace.

When calculating the "height" of a block, the old Blockly logic calculated the block along with any other blocks attached inside it, dramatically increasing the calculated height.

This works for calculating the necessary margins for all blocks inside a project, but it doesn't work well when trying to center the camera on a specific block.

This PR fixes the issue by making the height calculation optional - now it can work as before, or calculate the height of the block and **only** the block.