### PR TITLE
Changing identation to 4 spaces

### DIFF
--- a/core/generator.js
+++ b/core/generator.js
@@ -70,9 +70,11 @@ Blockly.Generator.prototype.STATEMENT_SUFFIX = null;
 /**
  * The method of indenting.  Defaults to two spaces, but language generators
  * may override this to increase indent or change to tabs.
+ *
+ * SHAPER NOTE: Setting the indent to 4 spaces instead of 2 (blockly default).
  * @type {string}
  */
-Blockly.Generator.prototype.INDENT = '  ';
+Blockly.Generator.prototype.INDENT = '    ';
 
 /**
  * Maximum length for a comment before wrapping.  Does not account for


### PR DESCRIPTION
Just that, 2 becomes 4. Seems to work on my little superficial tests. In addition, we could see if overriding this variable in the python generator sounds like a better way (thou I am not sure how overriding works in compressed files).