### PR TITLE
Lav camera string removal

### DIFF
--- a/blocks/camera_video.js
+++ b/blocks/camera_video.js
@@ -163,7 +163,6 @@ Blockly.Blocks.fable_draw_circle = {
       .setCheck('Number');
 
     this.appendValueInput('COLOUR')
-      .appendField(Blockly.Msg.FABLE_VIDEO_DRAW_COLOR)
       .setCheck('Colour');
 
     // Properties:
@@ -227,7 +226,6 @@ Blockly.Blocks.fable_draw_rect = {
       .setCheck('Number');
 
     this.appendValueInput('COLOUR')
-      .appendField(Blockly.Msg.FABLE_VIDEO_DRAW_COLOR)
       .setCheck('Colour');
 
     // Properties:
@@ -286,7 +284,6 @@ Blockly.Blocks.fable_draw_text = {
       .setCheck('Number');
 
     this.appendValueInput('COLOUR')
-      .appendField(Blockly.Msg.FABLE_VIDEO_DRAW_COLOR)
       .setCheck('Colour');
 
     // Properties:
@@ -308,7 +305,6 @@ Blockly.Blocks.fable_draw_text = {
     ];
 
     var toolboxKeywords = [
-      Blockly.Msg.FABLE_VIDEO_DRAW_COLOR,
       '%{BKY_FABLE_SEARCH_KEYWORD_TEXT}',
       '%{BKY_COLORS}'
     ];

--- a/core/generator.js
+++ b/core/generator.js
@@ -70,9 +70,11 @@ Blockly.Generator.prototype.STATEMENT_SUFFIX = null;
 /**
  * The method of indenting.  Defaults to two spaces, but language generators
  * may override this to increase indent or change to tabs.
+ *
+ * SHAPER NOTE: Setting the indent to 4 spaces instead of 2 (blockly default).
  * @type {string}
  */
-Blockly.Generator.prototype.INDENT = '  ';
+Blockly.Generator.prototype.INDENT = '    ';
 
 /**
  * Maximum length for a comment before wrapping.  Does not account for


### PR DESCRIPTION
The string VIDEO_DRAW_COLOR is empty in our language sheets (outcome of meeting with Moises). This PR just removes all the references of this from the block definitions, so we can safely removed the entry from the language file.

PS: This have also the indentation change (my fault), so please merge only AFTER the INDENTATION PR.