### PR TITLE
Quick blockly fixes

### DIFF
--- a/core/comment.js
+++ b/core/comment.js
@@ -232,7 +232,7 @@ Blockly.Comment.prototype.setVisible = function(visible) {
  * @private
  */
 Blockly.Comment.prototype.createBubble_ = function() {
-  if (!this.block_.isEditable() || Blockly.utils.userAgent.IE) {
+  if (!this.block_ || !this.block_.isEditable() || Blockly.utils.userAgent.IE) {
     // Steal the code from warnings to make an uneditable text bubble.
     // MSIE does not support foreignobject; textareas are impossible.
     // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-svg/56e6e04c-7c8c-44dd-8100-bd745ee42034

--- a/core/xml.js
+++ b/core/xml.js
@@ -74,6 +74,8 @@ Blockly.Xml.variablesToDom = function(variableList) {
     element.appendChild(Blockly.utils.xml.createTextNode(variable.name));
     if (variable.type) {
       element.setAttribute('type', variable.type);
+    } else {
+      element.setAttribute('type', '');
     }
     element.id = variable.getId();
     variables.appendChild(element);

--- a/generators/python/actions_common.js
+++ b/generators/python/actions_common.js
@@ -31,9 +31,15 @@ Blockly.Python.fable_speak = function (block) {
     lang = 'en';
   }
 
+  const matchGroups = /(str\()(.*)(\)\s\+\s'\s'\s\+\sstr\()(.*)(\))/gm.exec(text);
+  let croppedText = text;
+  if (matchGroups && matchGroups.length >= 5) {
+    croppedText = matchGroups[2] + matchGroups[4];
+  }
+
   var code = 'api.fableSpeak(str(' + text + '), "' + lang + '")\n';
 
-  if (text.length && text.length > 250) {
+  if (croppedText.length && croppedText.length > 250) {
     // 666 is a special ID in order to support easily removing the warning later, without clearing OTHER warnings on the block
     block.setWarningText(Blockly.Msg.FABLE_FIELD_WRN_TEXT_TOO_LONG, 666);
   } else {
@@ -48,7 +54,13 @@ Blockly.Python.fable_speak_lang = function (block) {
   var lang = block.getFieldValue('LANGUAGE');
   var code = 'api.fableSpeak(str(' + text + '), "' + lang + '")\n';
 
-  if (text.length && text.length > 30) {
+  const matchGroups = /(str\()(.*)(\)\s\+\s'\s'\s\+\sstr\()(.*)(\))/gm.exec(text);
+  let croppedText = text;
+  if (matchGroups && matchGroups.length >= 5) {
+    croppedText = matchGroups[2] + matchGroups[4];
+  }
+
+  if (croppedText.length && croppedText.length > 30) {
     // 666 is a special ID in order to support easily removing the warning later, without clearing OTHER warnings on the block
     block.setWarningText(Blockly.Msg.FABLE_FIELD_WRN_TEXT_TOO_LONG, 666);
   } else {


### PR DESCRIPTION
This fixes the following asana issues:

1. Comment bubble throws an error because `this.block_` is null during one of its methods.

2. [Opening a FAB with a module dropdown will not load the module if it is not in the recent modules list](https://app.asana.com/0/1139035657271725/1180139574148125) - by adding a `this.storedSelection` that gets sets when the block loads. If said "stored selection" is not in the options array, it gets added and greyed out as a "recent".

3. [FABs that use variables can't open in 1.6](https://app.asana.com/0/1139035657271725/1180139574148121) - the "type" attribute is needed in 1.6, made sure to add it to the FAB even if it's not available.

4. [fableSpeak triggers a "text too long" warning with less than 30 characters](https://app.asana.com/0/1139035657271725/1180139574148127) - Added a regex that removes any `str()`, `+ ' ' +` instances while calculating the length.