### PR TITLE
List block remaining shadow blocks onRemove fix

### DIFF
--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -226,15 +226,12 @@ Blockly.Blocks['lists_create_with'] = {
     var itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     var connections = [];
-    var counter = 0;
     while (itemBlock) {
       connections.push(itemBlock.valueConnection_);
       itemBlock = itemBlock.nextConnection &&
           itemBlock.nextConnection.targetBlock();
-      counter++;
     }
-    console.log(`COMPOSE: the number of attached blocks in the mutator is ${counter}`);
-    console.log(`The itemCount_ is ${this.itemCount_}`);
+
     // Disconnect any children that don't belong.
     for (var i = 0; i < this.itemCount_; i++) {
       var connection = this.getInput('ADD' + i).connection.targetConnection;
@@ -244,15 +241,15 @@ Blockly.Blocks['lists_create_with'] = {
         connection.disconnect();
         // SHAPE: When a child is about to be disconnected, save the reference of the block
         // that was attached to the input.
-        console.log(`Possible disconnection at input ADD${i}`);
         this.disconnectedChildBlocks.push(disconnectedChild);
       }
     }
+
     // SHAPE: Set flag to true if a new item was added to the list (from mutator bubble).
     this.addShadowBlocks = connections.length > this.itemCount_;
     this.itemCount_ = connections.length;
-    console.log(`The itemCount_ NOW is ${this.itemCount_}\n`);
     this.updateShape_();
+
     // Reconnect any child blocks.
     for (var i = 0; i < this.itemCount_; i++) {
       if (connections[i]) {
@@ -331,6 +328,7 @@ Blockly.Blocks['lists_create_with'] = {
    * @private
    * @this Blockly.Block
    * @author ShapeRoboticsApS
+   * @ignore
    */
   connectShadowBlock_: function () {
     // Spawn a shadow math blocks on empty inputs.

--- a/blocks/lists.js
+++ b/blocks/lists.js
@@ -167,8 +167,8 @@ Blockly.Blocks['lists_create_with'] = {
     this.setOutput(true, 'Array');
     this.setMutator(new Blockly.Mutator(['lists_create_with_item']));
     this.setTooltip(Blockly.Msg['LISTS_CREATE_WITH_TOOLTIP']);
-    this.child_disconnected_ = [];      //SHAPE: References to disconnected block children.
-    this.add_shadow = false;            //SHAPE: Flag to control the addition of a shadow block on new 'item'.
+    this.disconnectedChildBlocks = []; // SHAPE: Flag to control the removal of a shadow block on updateShape.
+    this.addShadowBlocks = false; // SHAPE: Flag to control the addition of a shadow block on updateShape.
   },
   ensureSearchKeywords: function() {
     var keywords = [
@@ -226,34 +226,39 @@ Blockly.Blocks['lists_create_with'] = {
     var itemBlock = containerBlock.getInputTargetBlock('STACK');
     // Count number of inputs.
     var connections = [];
+    var counter = 0;
     while (itemBlock) {
       connections.push(itemBlock.valueConnection_);
       itemBlock = itemBlock.nextConnection &&
           itemBlock.nextConnection.targetBlock();
+      counter++;
     }
+    console.log(`COMPOSE: the number of attached blocks in the mutator is ${counter}`);
+    console.log(`The itemCount_ is ${this.itemCount_}`);
     // Disconnect any children that don't belong.
     for (var i = 0; i < this.itemCount_; i++) {
       var connection = this.getInput('ADD' + i).connection.targetConnection;
-        if (connection && connections.indexOf(connection) == -1) {
-          //SHAPE: When a child is about to be disconnected, save the reference of the block
-          //that was attached to the input.
-          this.child_disconnected_.push(this.getInput('ADD' + i).connection.targetBlock());
-          
-          connection.disconnect();
-        }
+      if (connection && connections.indexOf(connection) == -1) {
+        // GoogleBlockly OG.
+        var disconnectedChild = this.getInput('ADD' + i).connection.targetBlock();
+        connection.disconnect();
+        // SHAPE: When a child is about to be disconnected, save the reference of the block
+        // that was attached to the input.
+        console.log(`Possible disconnection at input ADD${i}`);
+        this.disconnectedChildBlocks.push(disconnectedChild);
+      }
     }
-    //SHAPE: Set flag to true if a new item was added to the list (from mutator bubble).
-    this.add_shadow = connections.length > this.itemCount_;
-
+    // SHAPE: Set flag to true if a new item was added to the list (from mutator bubble).
+    this.addShadowBlocks = connections.length > this.itemCount_;
     this.itemCount_ = connections.length;
+    console.log(`The itemCount_ NOW is ${this.itemCount_}\n`);
     this.updateShape_();
-    //SHAPE: Reconnect any child blocks.
+    // Reconnect any child blocks.
     for (var i = 0; i < this.itemCount_; i++) {
-      Blockly.Mutator.reconnect(connections[i], this, 'ADD' + i);
+      if (connections[i]) {
+        Blockly.Mutator.reconnect(connections[i], this, 'ADD' + i);
+      }
     }
-
-    //SHAPE: Call method to add shadow math block if conditions are met.
-    this.connectShadowBlock_();
   },
   /**
    * Store pointers to any connected child blocks.
@@ -292,19 +297,33 @@ Blockly.Blocks['lists_create_with'] = {
         }
       }
     }
-    var j = 0;
     // Remove deleted inputs.
     while (this.getInput('ADD' + i)) {
-      //SHAPE: Delete a disconnected block ONLY if it is a shadow block.
-      if (this.child_disconnected_[j] && this.child_disconnected_[j].isShadow()) {
-          this.child_disconnected_[j].dispose(true, true);
-      }
       this.removeInput('ADD' + i);
       i++;
-      j++;      //SHAPE: Iterator for the disconnected children.
     }
-    //SHAPE: Reset array.
-    this.child_disconnected_ = [];
+    // SHAPE: delete disconnected child blocks.
+    if (this.disconnectedChildBlocks) {
+      while (this.disconnectedChildBlocks.length > 0) {
+        this.removeShadowBlock_(this.disconnectedChildBlocks.pop());
+      }
+    }
+    // SHAPe: add shadow blocks to empty inputs.
+    if (this.addShadowBlocks) {
+      // this.connectShadowBlock_();
+    }
+  },
+  /**
+   * Deletes a disconnected shadow child block if it
+   * was disconnected.
+   * @private
+   * @param {*} disconnectedChild The child block disconnected after composing the block.
+   * @author ShapeRoboticsApS
+   */
+  removeShadowBlock_: function (disconnectedChild) {
+    if (disconnectedChild.isShadow()) {
+      disconnectedChild.dispose(true, true);
+    }
   },
   /**
    * Connects a shadow math block with a random integer to a
@@ -313,19 +332,18 @@ Blockly.Blocks['lists_create_with'] = {
    * @this Blockly.Block
    * @author ShapeRoboticsApS
    */
-  connectShadowBlock_: function() {
-    if (this.add_shadow) {
-      // Spawn a new shadow math block.
-      var shadow_child = this.workspace.newBlock('math_number');
-      var random_int = 0; //Math.floor(Math.random() * 11);
-      shadow_child.setFieldValue(random_int, 'NUM');
-      shadow_child.setShadow(true);
-      shadow_child.initSvg();
-      shadow_child.render();
-      // Connect shadow block to last input.
-      var shadow_child_connection = shadow_child.outputConnection;
-      var parent_connection = this.getInput('ADD' + (this.itemCount_ - 1)).connection;
-      parent_connection.connect(shadow_child_connection);
+  connectShadowBlock_: function () {
+    // Spawn a shadow math blocks on empty inputs.
+    for (var i = 0; i < this.itemCount_; i++) {
+      if (this.getInput('ADD' + i) && !this.getInput('ADD' + i).connection.targetBlock()) {
+        var shadowChild = this.workspace.newBlock('math_number');
+        shadowChild.setFieldValue(0, 'NUM');
+        shadowChild.setShadow(true);
+        shadowChild.initSvg();
+        shadowChild.render();
+        // Connect ShadowBlock.
+        this.getInput('ADD' + i).connection.connect(shadowChild.outputConnection);
+      }
     }
   }
 };


### PR DESCRIPTION
Resolves ShapeRobotics/pc-standalone-app#305

This PR addresses the remaining disconnected shadow blocks when an input is removed from a List Block. It also removes the addition of shadow blocks when a new input is added.

### On REMOVE input from List Block mutator:
- On `compose`, the shadow block attached to a disconnected 'connection' is stored.
- On `updateShape_`, the stored array of disconnected children is inspected, removing any reference that is a Shadow block.

### On ADD input from List Block mutator:
- The addition of shadow blocks was disable; now an empty input is created.