### PR TITLE
Set selectedIndex_ to last option when out-of-bounds

### DIFF
--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -565,6 +565,15 @@ Blockly.FieldDropdown.prototype.render_ = function() {
 
   // Show correct element.
   var options = this.getOptions(true);
+
+  // ##SHAPE ROBOTICS##########################################################################################################################
+  if (this.selectedIndex_ && this.selectedIndex_ >= options.length) {
+    console.warn('Field Dropdown selected index out of bounds. Setting it to point to last option.' +
+                 `Values: selectedIndex_=${this.selectedIndex_}, options.length=${options.length}.`);
+    this.selectedIndex_ = options.length - 1;
+  }
+  // ###########################################################################################################################################
+
   var selectedOption = this.selectedIndex_ >= 0 &&
       options[this.selectedIndex_][0];
   if (selectedOption && typeof selectedOption == 'object') {


### PR DESCRIPTION
Resolves ShapeRobotics/pc-standalone-app#312

This PR addresses the issue of loading the cached workspace or saved files that have blocks using the '#' option to select a module ID. The '#' options creates a shadow `moduleId ` block that failed to render when the ID selected is not an active module.

This issue seemed to occur only with the shadow `moduleId` block added when selecting the #.

## On `FieldDropdown.prototype.render_`
- Check if the variable `selectedIndex_` is greater than the length of the options. If this is the case, the selected index is out of bounds.
https://github.com/ShapeRobotics/blockly/blob/6b796bf62f785fc13e3777d1908ba89f167a2db1/core/field_dropdown.js#L570

- Set the  `selectedIndex_` to point to the last option available, by assigning to it the value of `options.length - 1`.
https://github.com/ShapeRobotics/blockly/blob/6b796bf62f785fc13e3777d1908ba89f167a2db1/core/field_dropdown.js#L573