### PR TITLE
Angle picker wheel background to white

### DIFF
--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -237,7 +237,10 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
 
   var border = this.sourceBlock_.getColourBorder();
   border = border.colourBorder || border.colourLight;
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  Blockly.DropDownDiv.setColour('#ffffff', border);
+  // ######################################################################################################################
 
   Blockly.DropDownDiv.showPositionedByField(
       this, this.dropdownDispose_.bind(this));
@@ -288,9 +291,13 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
             Blockly.FieldAngle.HALF + ',' + Blockly.FieldAngle.HALF + ')'
       }, svg);
     }
-  
-    Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
-        this.sourceBlock_.getColour());
+
+    // # SHAPE ##############################################################################################################
+    // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
+        // this.sourceBlock_.getColour());
+    Blockly.DropDownDiv.setColour('#ffffff', this.sourceBlock_.getColour());
+    // ######################################################################################################################
+
     Blockly.DropDownDiv.showPositionedByField(this);
     // The angle picker is different from other fields in that it updates on
     // mousemove even if it's not in the middle of a drag.  In future we may

--- a/core/field_jointangle.js
+++ b/core/field_jointangle.js
@@ -235,7 +235,11 @@ Blockly.FieldJointAngle.prototype.showEditor_ = function () {
 
   var border = this.sourceBlock_.getColourBorder();
   border = border.colourBorder || border.colourLight;
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  Blockly.DropDownDiv.setColour('#ffffff', border);
+  // ######################################################################################################################
 
   Blockly.DropDownDiv.showPositionedByField(
     this, this.dropdownDispose_.bind(this));
@@ -297,8 +301,12 @@ Blockly.FieldJointAngle.prototype.dropdownCreate_ = function () {
     transform: 'rotate(0,' + Blockly.FieldJointAngle.HALF + ',' + Blockly.FieldJointAngle.HALF + ')'
   }, svg);
 
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
-    this.sourceBlock_.getColour());
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
+      // this.sourceBlock_.getColour());
+  Blockly.DropDownDiv.setColour('#ffffff', this.sourceBlock_.getColour());
+  // ######################################################################################################################
+
   Blockly.DropDownDiv.showPositionedByField(this);
   // The angle picker is different from other fields in that it updates on
   // mousemove even if it's not in the middle of a drag.  In future we may


### PR DESCRIPTION
Resolves ShapeRobotics/pc-standalone-app#313

This PR changes the background color of the angle picker wheel to white. By the default, Blockly set this color based on the source block, which get its color from the category.

The changes are implemented in both _**field_angle.js**_ and _**field_jointangle.js**_ 

## On `FieldAngle.prototype.showEditor_`
- Set the color to white (#ffffff) instead of `sourceBlock_.getColour()`.

## On `FieldAngle.prototype.dropdownCreate_`
- Set the color to white (#ffffff) instead of `sourceBlock_.getColour()`.