### PR TITLE
Grayed out only applied to module id's dynamic dropdown

### DIFF
--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -130,6 +130,12 @@ Blockly.DropDownDiv.animateOutTimer_ = null;
 Blockly.DropDownDiv.onHide_ = null;
 
 /**
+ * Stores the Field name reference this DrodDownDiv is attached to.
+ * @author Shape Robotics
+ */
+Blockly.DropDownDiv.sourceFieldID_ = null;
+
+/**
  * Create and insert the DOM element for this div.
  */
 Blockly.DropDownDiv.createDom = function() {
@@ -211,6 +217,14 @@ Blockly.DropDownDiv.setColour = function(backgroundColour, borderColour) {
  */
 Blockly.DropDownDiv.setCategory = function(category) {
   Blockly.DropDownDiv.DIV_.setAttribute('data-category', category);
+};
+
+/**
+ * Returns the source Field name this DropDownDiv is 'attached' to.
+ * @author Shape Robotics
+ */
+Blockly.DropDownDiv.getSourceFieldID = function () {
+  return Blockly.DropDownDiv.sourceFieldID_;
 };
 
 /**
@@ -334,17 +348,21 @@ Blockly.DropDownDiv.show = function(owner, rtl, primaryX, primaryY,
       metrics.initialX, metrics.initialY,
       metrics.finalX, metrics.finalY);
 
-  // SHAPE: Added from blockly_changes
-  // When showing (aka opening) the dropdown, wait for 100 ms and modify the colors of recent modules.
-  setTimeout(function () {
-    Blockly.FieldDropdown.changeRecentModuleColors(Fable.Data.Modules.activeModules, Fable.Data.Modules.recentModules);
-  }, 100);
+  // # SHAPE ####################################################################################################################
+  // When showing (opening) the dropdown, wait for 100 ms and modify the colors of recent modules.
+  console.log(Blockly.DropDownDiv.sourceFieldID_);
+  // Only do so for the DynamicIDDropDowns.
+  if (Blockly.DropDownDiv.sourceFieldID_ === 'ID') {
+    setTimeout(function () {
+      Blockly.FieldDropdown.changeRecentModuleColors(Fable.Data.Modules.activeModules, Fable.Data.Modules.recentModules);
+    }, 100);
 
-  // SHAPE: Added from blockly_changes
-  // After opening the dropdown, check the recent module colors every 1000 ms for changes.
-  Blockly.DropDownDiv.intervalID = setInterval(function () {
-    Blockly.FieldDropdown.changeRecentModuleColors(Fable.Data.Modules.activeModules, Fable.Data.Modules.recentModules);
-  }, 1000);
+    // After opening the dropdown, check the recent module colors every 1000 ms for changes.
+    Blockly.DropDownDiv.intervalID = setInterval(function () {
+      Blockly.FieldDropdown.changeRecentModuleColors(Fable.Data.Modules.activeModules, Fable.Data.Modules.recentModules);
+    }, 1000);
+  }
+  // ##########################################################################################################################
 
   return metrics.arrowAtTop;
 };
@@ -593,12 +611,13 @@ Blockly.DropDownDiv.hide = function() {
     Blockly.DropDownDiv.onHide_ = null;
   }
 
-  // SHAPE: Added from blockly_changes
-  // Stop the iterative execution of the changeRecentModuleColors function, if the dropdown was just opened. See Blockly.DropDownDiv.show overload in this file.
+  // # SHAPE ####################################################################################################################
+  // Stop the iterative execution of the changeRecentModuleColors function, if the dropdown was just opened.
   if (Blockly.DropDownDiv.intervalID > 0) {
     clearInterval(Blockly.DropDownDiv.intervalID);
     Blockly.DropDownDiv.intervalID = -1;
   }
+  // ##########################################################################################################################
 };
 
 /**
@@ -611,6 +630,14 @@ Blockly.DropDownDiv.hideWithoutAnimation = function() {
   if (Blockly.DropDownDiv.animateOutTimer_) {
     clearTimeout(Blockly.DropDownDiv.animateOutTimer_);
   }
+
+  // # SHAPE ####################################################################################################################
+  // Stop the iterative execution of the changeRecentModuleColors function.
+  if (Blockly.DropDownDiv.intervalID > 0) {
+    clearInterval(Blockly.DropDownDiv.intervalID);
+    Blockly.DropDownDiv.intervalID = -1;
+  }
+  // ##########################################################################################################################
 
   // Reset style properties in case this gets called directly
   // instead of hide() - see discussion on #2551.

--- a/core/dropdowndiv.js
+++ b/core/dropdowndiv.js
@@ -350,7 +350,6 @@ Blockly.DropDownDiv.show = function(owner, rtl, primaryX, primaryY,
 
   // # SHAPE ####################################################################################################################
   // When showing (opening) the dropdown, wait for 100 ms and modify the colors of recent modules.
-  console.log(Blockly.DropDownDiv.sourceFieldID_);
   // Only do so for the DynamicIDDropDowns.
   if (Blockly.DropDownDiv.sourceFieldID_ === 'ID') {
     setTimeout(function () {

--- a/core/field_angle.js
+++ b/core/field_angle.js
@@ -237,7 +237,10 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
 
   var border = this.sourceBlock_.getColourBorder();
   border = border.colourBorder || border.colourLight;
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  Blockly.DropDownDiv.setColour('#ffffff', border);
+  // ######################################################################################################################
 
   Blockly.DropDownDiv.showPositionedByField(
       this, this.dropdownDispose_.bind(this));
@@ -288,9 +291,13 @@ Blockly.FieldAngle.prototype.showEditor_ = function() {
             Blockly.FieldAngle.HALF + ',' + Blockly.FieldAngle.HALF + ')'
       }, svg);
     }
-  
-    Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
-        this.sourceBlock_.getColour());
+
+    // # SHAPE ##############################################################################################################
+    // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
+        // this.sourceBlock_.getColour());
+    Blockly.DropDownDiv.setColour('#ffffff', this.sourceBlock_.getColour());
+    // ######################################################################################################################
+
     Blockly.DropDownDiv.showPositionedByField(this);
     // The angle picker is different from other fields in that it updates on
     // mousemove even if it's not in the middle of a drag.  In future we may

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -225,6 +225,10 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   Blockly.utils.dom.addClass(
       /** @type {!Element} */ (this.menu_.getElement()), 'blocklyDropdownMenu');
 
+  // # SHAPE ####################################################################################################################
+  Blockly.DropDownDiv.sourceFieldID_ = this.name; // Store a reference of this Field name.
+  // ############################################################################################################################
+
   Blockly.DropDownDiv.showPositionedByField(
       this, this.dropdownDispose_.bind(this));
 
@@ -661,10 +665,12 @@ Blockly.FieldDropdown.prototype.getText_ = function() {
   return selectedOption;
 };
 
-/*
-* SHAPE: Added from blockly_changes
-* Iterates through a dropdown and changes the colors of recent modules to grey them out.
-*/
+/**
+ * Iterates through a dropdown and changes the colors of recent modules to grey them out.
+ * @param activeIDsDict The list of current active modules.
+ * @param recentIDsDict The list of 'seen' modules.
+ * @author Shape Robotics
+ */
 Blockly.FieldDropdown.changeRecentModuleColors = function (activeIDsDict, recentIDsDict) {
   // Find the dropdown HTML element
   var dropdownDiv = document.getElementsByClassName('blocklyDropDownDiv');
@@ -693,7 +699,7 @@ Blockly.FieldDropdown.changeRecentModuleColors = function (activeIDsDict, recent
     return;
   }
 
-  // The following 30 or lines generate two lists for the active and recent modules.
+  // The following lines generate two lists for the active and recent modules.
   // Those lists contain ALL active/recent modules as strings. Makes for easier search later.
   var listOfActiveModules = [];
   var listOfRecentModules = [];

--- a/core/field_jointangle.js
+++ b/core/field_jointangle.js
@@ -235,7 +235,11 @@ Blockly.FieldJointAngle.prototype.showEditor_ = function () {
 
   var border = this.sourceBlock_.getColourBorder();
   border = border.colourBorder || border.colourLight;
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(), border);
+  Blockly.DropDownDiv.setColour('#ffffff', border);
+  // ######################################################################################################################
 
   Blockly.DropDownDiv.showPositionedByField(
     this, this.dropdownDispose_.bind(this));
@@ -297,8 +301,12 @@ Blockly.FieldJointAngle.prototype.dropdownCreate_ = function () {
     transform: 'rotate(0,' + Blockly.FieldJointAngle.HALF + ',' + Blockly.FieldJointAngle.HALF + ')'
   }, svg);
 
-  Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
-    this.sourceBlock_.getColour());
+  // # SHAPE ##############################################################################################################
+  // Blockly.DropDownDiv.setColour(this.sourceBlock_.getColour(),
+      // this.sourceBlock_.getColour());
+  Blockly.DropDownDiv.setColour('#ffffff', this.sourceBlock_.getColour());
+  // ######################################################################################################################
+
   Blockly.DropDownDiv.showPositionedByField(this);
   // The angle picker is different from other fields in that it updates on
   // mousemove even if it's not in the middle of a drag.  In future we may


### PR DESCRIPTION
Resolves ShapeRobotics/pc-standalone-app#314

This PR addresses the issue of dropdowns with static options (like the PlayNote, PlaySound) were being grayed out, the same way as the recent modules in the dynamic module id dropdows.

The logic of graying out **recent but not active** modules id's was meant only for those dropdowns displaying module id's, so the other dropdowns should not display this styling.

**REMARK: this PR have the angle picker wheel background changes, so merge this ONLY AFTER pull request #49 .**

## File **core/dropdowndiv.js**:

### New property `sourceFieldID_`
- A new class property was implemented, called `DropDownDiv.sourceFieldID_`. This property is set to store the reference of the source block's field where the dropdown is attached.
- A getter was implemented to read this property.

### On `DropDownDiv.show`
- Check if the `sourceFieldID_` references a field named 'ID'. These fields are named on the block definition, and consistently references field dropdowns having the list of module ids.
https://github.com/ShapeRobotics/blockly/blob/aa1350f921edb44013a78c031f6e3a7bfe229488/core/dropdowndiv.js#L355

- If the `sourceFieldID_` is indeed a module id dropdown, trigger the method `FieldDropdown.changeRecentModuleColors()`, and the interval checking for the open dropdown module ids.
https://github.com/ShapeRobotics/blockly/blob/aa1350f921edb44013a78c031f6e3a7bfe229488/core/dropdowndiv.js#L356-L363

### On `DropDownDiv.hideWithoutAnimation`
- Reset the interval, so the loop stops. The interval was being clear only on `DropDownDiv.hide`, but most of the dropdown divs are closed without animation.
https://github.com/ShapeRobotics/blockly/blob/aa1350f921edb44013a78c031f6e3a7bfe229488/core/dropdowndiv.js#L636-L639

## File **core/filed_dropdown.js**

###  On `FieldDropdown.prototype.showEditor_`
- Set the DropDownDiv `sourceFieldID_`  to the field's name value.
https://github.com/ShapeRobotics/blockly/blob/aa1350f921edb44013a78c031f6e3a7bfe229488/core/field_dropdown.js#L229